### PR TITLE
Download data with AWS S3

### DIFF
--- a/Database_load_Tutorial.ipynb
+++ b/Database_load_Tutorial.ipynb
@@ -51,7 +51,8 @@
       "source": [
         "#@title Install dependencies \n",
         "!git clone https://github.com/N-Nieto/Inner_Speech_Dataset -q\n",
-        "!pip3 install mne -q"
+        "!pip3 install mne -q\n",
+        "!pip install awscli"
       ]
     },
     {
@@ -86,7 +87,7 @@
         "id": "gcXsT133Chus"
       },
       "source": [
-        "## Data Loading."
+        "## Download data."
       ]
     },
     {
@@ -109,8 +110,8 @@
         }
       ],
       "source": [
-        "# Mount drive with data. You have to download and store the dataset in your own Drive\n",
-        "drive.mount('/gdrive', force_remount=True)"
+        "# Download data from AWS as described in OpenNeuro\n",
+        "!aws s3 sync --no-sign-request s3://openneuro.org/ds003626 data"
       ]
     },
     {
@@ -124,7 +125,7 @@
         "### Hyperparameters\n",
         "\n",
         "# The root dir has to point to the folder that contains the database\n",
-        "root_dir = \"/gdrive/My Drive/...\"\n",
+        "root_dir = \"data\"\n",
         "\n",
         "# Data Type\n",
         "datatype = \"EEG\"\n",


### PR DESCRIPTION
`Database_load_Tutorial.ipyn` was modified to download the dataset from AWS S3 instead of mounting it on google drive. Downloads takes around 3 minutes and it one of the ways recommended in OpenNeuro. 

Changes:
* Added aws client with pip
* Change title from "Data Loading" to  "Downloading data"
* The dataset is store in the folder "data"